### PR TITLE
Added compatibility for IDE version 2022.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 
 plugins {
     java
-    kotlin("jvm") version "1.5.10"
+    kotlin("jvm") version "1.7.10"
     id("org.jetbrains.intellij") version "1.3.0"
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ jvmVersion=11
 group=dev.meanmail
 repository=https://github.com/meanmail-dev/nginx-intellij-plugin
 pluginName=nginx-intellij-plugin
-version=2021.3
+version=2022.2
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency=false
 #
 # Platform
-platformVersion=2021.3
+platformVersion=2022.2
 platformType=PC
-usePlugins=com.tang:1.3.6.220-IDEA213
+usePlugins=com.tang:1.3.7.2-IDEA222
 #
 # Publish
 publishChannel=default


### PR DESCRIPTION
Hi,

I've gone ahead and versioned the plugin for IntelliJ 2022.2; Initially, I was aiming to support multiple versions, but seeing as there are tags for each individual version, I'm not sure how to proceed;

This is my first ever interaction with the Jetbrains Plugin ecosystem, so if I messed something up, please let me know, but initial testing in GoLand 2022.2.2 (GO-222.3739.57) indicates that it works!

This PR should close #12.