### PR TITLE
Added some missing contexts to js directives

### DIFF
--- a/src/main/kotlin/dev/meanmail/directives/nginx/http/ngx_http_js_module.kt
+++ b/src/main/kotlin/dev/meanmail/directives/nginx/http/ngx_http_js_module.kt
@@ -21,7 +21,7 @@ val jsImport = Directive(
             required = true
         )
     ),
-    context = listOf(http),
+    context = listOf(http, server, location),
     module = ngx_http_js_module
 )
 

--- a/src/main/kotlin/dev/meanmail/directives/nginx/stream/ngx_stream_js_module.kt
+++ b/src/main/kotlin/dev/meanmail/directives/nginx/stream/ngx_stream_js_module.kt
@@ -196,7 +196,7 @@ val streamJsImport = Directive(
             required = true
         )
     ),
-    context = listOf(stream),
+    context = listOf(stream, streamServer),
     module = ngx_stream_js_module
 )
 
@@ -284,7 +284,7 @@ val streamJsPath = Directive(
             required = true
         )
     ),
-    context = listOf(stream),
+    context = listOf(stream, streamServer),
     module = ngx_stream_js_module
 )
 
@@ -326,7 +326,7 @@ val streamJsPreloadObject = Directive(
             required = true
         )
     ),
-    context = listOf(stream),
+    context = listOf(stream, streamServer),
     module = ngx_stream_js_module
 )
 


### PR DESCRIPTION
I have noticed today that some js directives are reported by the plugin although they are used at valid places.
This PR updates those directives based on the documentation at
- https://nginx.org/en/docs/stream/ngx_stream_js_module.html
- https://nginx.org/en/docs/http/ngx_http_js_module.html

Most changes have been introduced with version 0.7.7. Only the stream js_preload_object always has been valid in both `stream` and `server`.