### PR TITLE
Fix Java version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
 
       - name: Test
         run: ./gradlew test
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
 
       - name: Build with Gradle
         run: ./gradlew buildPlugin


### PR DESCRIPTION
Commit be0b9a99278aed64402b5f2f63055904e228c02c bumped jvmVersion to 21, but CI workflows were not updated accordingly. This broke the workflows resulting in the following error:

> Java compilation initialization error
    error: invalid source release: 21