### PR TITLE
Add 'grpc_ssl_server_name' to fix Nginx completion tests

### DIFF
--- a/src/test/kotlin/dev/meanmail/codeInsight/completion/NginxCompletionContributorTest.kt
+++ b/src/test/kotlin/dev/meanmail/codeInsight/completion/NginxCompletionContributorTest.kt
@@ -50,6 +50,7 @@ class NginxCompletionContributorTest : BasePlatformTestCase() {
                 server<caret>
             }
         """.trimIndent(),
+            "grpc_ssl_server_name",
             "proxy_ssl_server_name",
             "server",
             "server_name_in_redirect",


### PR DESCRIPTION
Commit be0b9a99278aed64402b5f2f63055904e228c02c added 'grpc_ssl_server_name' to http context, which broke this test.