### PR TITLE
Fix scgi_pass directive context

### DIFF
--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_scgi_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_scgi_module.kt
@@ -301,7 +301,7 @@ val scgiPass = Directive(
         
         Can also specify a server group defined in the upstream block.
     """.trimIndent(),
-    context = listOf(location, `if`),
+    context = listOf(location, locationIf),
     module = ngx_http_scgi_module
 )
 


### PR DESCRIPTION
`scgi_pass` is only supported in `location` and `if in location` context.