### PR TITLE
Fix directive context mismatches (#64)

### DIFF
--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/auth/ngx_http_auth_basic_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/auth/ngx_http_auth_basic_module.kt
@@ -3,6 +3,7 @@ package dev.meanmail.directives.catalog.nginx.http.auth
 import dev.meanmail.directives.catalog.Directive
 import dev.meanmail.directives.catalog.NginxModule
 import dev.meanmail.directives.catalog.nginx.http.http
+import dev.meanmail.directives.catalog.nginx.http.limitExcept
 import dev.meanmail.directives.catalog.nginx.http.location
 import dev.meanmail.directives.catalog.nginx.http.server
 
@@ -16,13 +17,13 @@ val ngx_http_auth_basic_module = NginxModule(
 val authBasic = Directive(
     name = "auth_basic",
     description = "Enables HTTP basic authentication and specifies the authentication realm",
-    context = listOf(http, server, location),
+    context = listOf(http, server, location, limitExcept),
     module = ngx_http_auth_basic_module
 )
 
 val authBasicUserFile = Directive(
     name = "auth_basic_user_file",
     description = "Specifies the path to the file containing user credentials for basic authentication",
-    context = listOf(http, server, location),
+    context = listOf(http, server, location, limitExcept),
     module = ngx_http_auth_basic_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/limit/ngx_http_limit_req_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/limit/ngx_http_limit_req_module.kt
@@ -16,7 +16,7 @@ val ngx_http_limit_req_module = NginxModule(
 val limitReqZone = Directive(
     name = "limit_req_zone",
     description = "Defines a shared memory zone for tracking request rate limits",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_limit_req_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_acme_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_acme_module.kt
@@ -48,7 +48,7 @@ val acmeAccountKey = Directive(
 val acmeCertificate = Directive(
     name = "acme_certificate",
     description = "Defines a certificate with domain identifiers for automatic management",
-    context = listOf(http),
+    context = listOf(server),
     module = ngx_http_acme_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_charset_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_charset_module.kt
@@ -12,7 +12,7 @@ val ngx_http_charset_module = NginxModule(
 val charset = Directive(
     name = "charset",
     description = "Sets the character set for responses",
-    context = listOf(http, server, location),
+    context = listOf(http, server, location, locationIf),
     module = ngx_http_charset_module
 )
 
@@ -40,6 +40,6 @@ val overrideCharset = Directive(
 val sourceCharset = Directive(
     name = "source_charset",
     description = "Specifies the source character set for conversion",
-    context = listOf(http, server, location),
+    context = listOf(http, server, location, locationIf),
     module = ngx_http_charset_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_dav_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_dav_module.kt
@@ -12,7 +12,7 @@ val ngx_http_dav_module = NginxModule(
 val createFullPutPath = Directive(
     "create_full_put_path",
     "Enables creation of intermediate directories during PUT requests",
-    context = listOf(location),
+    context = listOf(http, server, location),
     module = ngx_http_dav_module
 )
 
@@ -26,13 +26,13 @@ val davAccess = Directive(
 val davMethods = Directive(
     name = "dav_methods",
     description = "Enables WebDAV HTTP methods for the location",
-    context = listOf(location),
+    context = listOf(http, server, location),
     module = ngx_http_dav_module
 )
 
 val minDeleteDepth = Directive(
     name = "min_delete_depth",
     description = "Sets the minimum directory depth allowed for DELETE requests",
-    context = listOf(location),
+    context = listOf(http, server, location),
     module = ngx_http_dav_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_fastcgi_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_fastcgi_module.kt
@@ -124,7 +124,7 @@ val fastcgiCachePath = Directive(
 val fastcgiCachePurge = Directive(
     name = "fastcgi_cache_purge",
     description = "Defines conditions for purging cached content",
-    context = listOf(http, location),
+    context = listOf(http, server, location),
     module = ngx_http_fastcgi_module
 )
 
@@ -369,7 +369,7 @@ val fastcgiStoreAccess = Directive(
 val fastcgiTempPath = Directive(
     name = "fastcgi_temp_path",
     description = "Defines the directory for storing temporary files when buffering FastCGI server responses",
-    context = listOf(http),
+    context = listOf(http, server, location),
     module = ngx_http_fastcgi_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_geoip_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_geoip_module.kt
@@ -13,34 +13,34 @@ val ngx_http_geoip_module = NginxModule(
 val geoipCountry = Directive(
     name = "geoip_country",
     description = "Specifies the path to the MaxMind GeoIP country database for determining the country of the client's IP address",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_geoip_module
 )
 
 val geoipCity = Directive(
     name = "geoip_city",
     description = "Specifies the path to the MaxMind GeoIP city database for determining detailed location information",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_geoip_module
 )
 
 val geoipOrg = Directive(
     name = "geoip_org",
     description = "Specifies the path to the MaxMind GeoIP organization database for determining the organization associated with an IP address",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_geoip_module
 )
 
 val geoipProxy = Directive(
     name = "geoip_proxy",
     description = "Defines trusted proxy networks for correctly identifying the original client IP address when behind a proxy",
-    context = listOf(http, server),
+    context = listOf(http),
     module = ngx_http_geoip_module
 )
 
 val geoipProxyRecursive = Directive(
     name = "geoip_proxy_recursive",
     description = "Determines whether to recursively search for the original client IP address through multiple proxy layers",
-    context = listOf(http, server),
+    context = listOf(http),
     module = ngx_http_geoip_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_gunzip_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_gunzip_module.kt
@@ -19,6 +19,6 @@ val gunzip = Directive(
 val gunzipBuffers = Directive(
     name = "gunzip_buffers",
     description = "Configures the number and size of buffers used for decompressing gzipped responses. This directive allows fine-tuning memory allocation for gunzip operations.",
-    context = listOf(location),
+    context = listOf(http, server, location),
     module = ngx_http_gunzip_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_js_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_js_module.kt
@@ -26,7 +26,7 @@ val jsInclude = Directive(
 val jsPath = Directive(
     name = "js_path",
     description = "Sets the search path for JavaScript modules used in Nginx configuration",
-    context = listOf(http),
+    context = listOf(http, server, location),
     module = ngx_http_js_module
 )
 
@@ -47,14 +47,14 @@ val jsPreloadObject = Directive(
 val jsBodyFilter = Directive(
     name = "js_body_filter",
     description = "Applies a JavaScript function to modify the response body before sending to the client",
-    context = listOf(http, server, location),
+    context = listOf(location, locationIf, limitExcept),
     module = ngx_http_js_module
 )
 
 val jsContent = Directive(
     name = "js_content",
     description = "Specifies a JavaScript function to handle request content",
-    context = listOf(http, server, location),
+    context = listOf(location, locationIf, limitExcept),
     module = ngx_http_js_module
 )
 
@@ -131,7 +131,7 @@ val jsFetchVerifyDepth = Directive(
 val jsHeaderFilter = Directive(
     name = "js_header_filter",
     description = "Applies a JavaScript function to modify response headers before sending to the client",
-    context = listOf(http, server, location),
+    context = listOf(location, locationIf, limitExcept),
     module = ngx_http_js_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_log_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_log_module.kt
@@ -27,6 +27,6 @@ val logFormat = Directive(
 val openLogFileCache = Directive(
     name = "open_log_file_cache",
     description = "Configures caching of log file descriptors to improve performance",
-    context = listOf(http),
+    context = listOf(http, server, location),
     module = ngx_http_log_module
 )

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_proxy_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_proxy_module.kt
@@ -124,14 +124,14 @@ val proxyCacheMinUses = Directive(
 val proxyCachePath = Directive(
     name = "proxy_cache_path",
     description = "Sets the path and configuration for the cache",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_proxy_module
 )
 
 val proxyCachePurge = Directive(
     name = "proxy_cache_purge",
     description = "Defines conditions for purging cache entries",
-    context = listOf(http),
+    context = listOf(http, server, location),
     module = ngx_http_proxy_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_referer_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_referer_module.kt
@@ -13,14 +13,14 @@ val ngx_http_referer_module = NginxModule(
 val refererHashBucketSize = Directive(
     name = "referer_hash_bucket_size",
     description = "Sets the size of hash bucket for the referer hash table to optimize memory usage",
-    context = listOf(http),
+    context = listOf(server, location),
     module = ngx_http_referer_module
 )
 
 val refererHashMaxSize = Directive(
     name = "referer_hash_max_size",
     description = "Sets the maximum size of the referer hash table to control memory allocation",
-    context = listOf(http),
+    context = listOf(server, location),
     module = ngx_http_referer_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_scgi_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_scgi_module.kt
@@ -149,7 +149,7 @@ val scgiCacheMinUses = Directive(
 val scgiCachePath = Directive(
     name = "scgi_cache_path",
     description = "Defines the path for caching SCGI server responses",
-    context = listOf(http, server, location),
+    context = listOf(http),
     module = ngx_http_scgi_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_ssl_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_ssl_module.kt
@@ -114,7 +114,7 @@ val sslOcsp = Directive(
 val sslOcspCache = Directive(
     name = "ssl_ocsp_cache",
     description = "Configures the storage of OCSP responses for SSL connections",
-    context = listOf(http),
+    context = listOf(http, server),
     module = ngx_http_ssl_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_v2_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_v2_module.kt
@@ -82,7 +82,7 @@ val http2PushPreload = Directive(
 val http2RecvBufferSize = Directive(
     name = "http2_recv_buffer_size",
     description = "Sets the size of the receive buffer for HTTP/2 connections",
-    context = listOf(http, server),
+    context = listOf(http),
     module = ngx_http_v2_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_v3_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/http/ngx_http_v3_module.kt
@@ -2,6 +2,7 @@ package dev.meanmail.directives.catalog.nginx.http
 
 import dev.meanmail.directives.catalog.Directive
 import dev.meanmail.directives.catalog.NginxModule
+import dev.meanmail.directives.catalog.main
 
 // https://nginx.org/en/docs/http/ngx_http_v3_module.html
 
@@ -48,7 +49,7 @@ val quicActiveConnectionIdLimit = Directive(
 val quicBpf = Directive(
     name = "quic_bpf",
     description = "Enables routing of QUIC packets using eBPF (Linux 5.7+)",
-    context = listOf(http),
+    context = listOf(main),
     module = ngx_http_v3_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_js_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_js_module.kt
@@ -133,7 +133,7 @@ val streamJsPath = Directive(
 val streamJsPeriodic = Directive(
     name = "js_periodic",
     description = "Configures periodic JavaScript tasks in stream context",
-    context = listOf(stream, streamServer),
+    context = listOf(streamServer),
     module = ngx_stream_js_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_proxy_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_proxy_module.kt
@@ -69,7 +69,7 @@ val streamProxyNextUpstreamTries = Directive(
 val streamProxyPass = Directive(
     name = "proxy_pass",
     description = "Defines the destination server or server group for proxying stream connections",
-    context = listOf(stream, streamServer),
+    context = listOf(streamServer),
     module = ngx_stream_proxy_module
 )
 

--- a/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_set_module.kt
+++ b/directive-catalog/src/main/kotlin/dev/meanmail/directives/catalog/nginx/stream/ngx_stream_set_module.kt
@@ -13,6 +13,6 @@ val ngx_stream_set_module = NginxModule(
 val streamSet = Directive(
     name = "set",
     description = "Sets a value of a variable in stream context",
-    context = listOf(stream, streamServer),
+    context = listOf(streamServer),
     module = ngx_stream_set_module
 )


### PR DESCRIPTION
## Summary
- Fix wrong contexts for 7 directives (acme_certificate, quic_bpf, referer_hash_*, js_body_filter, js_content, js_header_filter)
- Add missing contexts for 14 directives (auth_basic*, charset, source_charset, dav directives, fastcgi_cache_purge, fastcgi_temp_path, proxy_cache_purge, gunzip_buffers, js_path, open_log_file_cache, ssl_ocsp_cache)
- Remove extra contexts for 9 directives (geoip_*, limit_req_zone, http2_recv_buffer_size, proxy_cache_path, scgi_cache_path)
- Remove spurious `stream` context from 3 stream directives (proxy_pass, set, js_periodic)

All changes validated against nginx.org XML reference documentation.

Closes #64

## Test plan
- [x] `./gradlew build` passes successfully
- [ ] Verify directive context validation works correctly in the IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)