### PR TITLE
Fix inspection shortName conflict with pro plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2026.1.8 (March, 1, 2026)
+
+* Fix inspection shortName conflict between free and pro plugins — rename `NginxDirectiveValueInspection` to `NginxDirectiveInspection` to avoid `PluginException: Short name is not unique` when both plugins are installed
+
 ## 2026.1.7 (February, 22, 2026)
 
 * Fix parsing of unquoted string with multiple `&` and variables in directives like `proxy_cache_key` (e.g. `proxy_cache_key $uri?a=$arg_a&b=$arg_b&c=$arg_c;`) ([#76](https://github.com/meanmail-dev/nginx-intellij-plugin/issues/76))

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ jvmVersion=21
 group=dev.meanmail
 repository=https://github.com/meanmail-dev/nginx-intellij-plugin
 pluginName=Nginx Configuration
-version=2026.1.7
+version=2026.1.8
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency=false
 #

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -104,7 +104,12 @@
 
 Your ratings and feedback are very important. The feature will appear the faster the more people request it.
 ]]></description>
-    <change-notes></change-notes>
+    <change-notes><![CDATA[
+<b>2026.1.8</b>
+<ul>
+    <li>Fix inspection shortName conflict between free and pro plugins</li>
+</ul>
+]]></change-notes>
 
     <depends>com.intellij.modules.lang</depends>
 
@@ -125,7 +130,7 @@ Your ratings and feedback are very important. The feature will appear the faster
                 groupName="Nginx"
                 enabledByDefault="true"
                 level="ERROR"
-                shortName="NginxDirectiveValueInspection"/>
+                shortName="NginxDirectiveInspection"/>
         <localInspection
                 language="Nginx Configuration"
                 implementationClass="dev.meanmail.codeInsight.inspections.NginxGeoInspection"


### PR DESCRIPTION
## Summary
- Rename inspection `shortName` from `NginxDirectiveValueInspection` to `NginxDirectiveInspection` in `plugin.xml` to match the actual class name
- Fixes `PluginException: Short name 'NginxDirectiveValueInspection' is not unique` when both free and pro plugins are installed simultaneously
- Bump version to 2026.1.8

## Test plan
- [ ] Install both free and pro plugins in the same IDE — no `PluginException` on startup
- [ ] Verify the directive inspection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)