### PR TITLE
Bump version to 2026.1.13 with release notes for analytics consent fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ jvmVersion=21
 group=dev.meanmail
 repository=https://github.com/meanmail-dev/nginx-intellij-plugin
 pluginName=Nginx Configuration
-version=2026.1.12
+version=2026.1.13
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency=false
 #

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,6 +105,11 @@
 Your ratings and feedback are very important. The feature will appear the faster the more people request it.
 ]]></description>
     <change-notes><![CDATA[
+<b>2026.1.13 (April, 1, 2026)</b>
+<ul>
+    <li>Fix analytics consent dialog reappearing after user denial</li>
+</ul>
+
 <b>2026.1.12 (March, 28, 2026)</b>
 <ul>
     <li>Fix UI freeze caused by blocking HTTP requests on EDT when sending analytics data — network calls are now executed on a pooled thread</li>


### PR DESCRIPTION
## Summary
- Bump plugin version from 2026.1.12 to 2026.1.13
- Add release notes entry for analytics consent dialog fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)