### PR TITLE
Fix analytics write lock crash and improve queue reliability

### DIFF
--- a/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsService.kt
+++ b/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsService.kt
@@ -1,9 +1,12 @@
 package dev.meanmail.analytics
 
 import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.intellij.ide.plugins.PluginManagerCore
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationInfo
+import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.application.PermanentInstallationID
 import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.extensions.PluginId
@@ -11,6 +14,8 @@ import com.intellij.ui.LicensingFacade
 import com.intellij.util.concurrency.AppExecutorUtil
 import com.intellij.util.io.HttpRequests
 import java.net.HttpURLConnection
+import java.nio.file.Files
+import java.nio.file.Path
 import java.security.MessageDigest
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.TimeUnit
@@ -20,10 +25,14 @@ open class AnalyticsService(
     private val settings: AnalyticsSettings,
 ) : Disposable {
     private val gson = Gson()
+    private val queueType = object : TypeToken<List<Map<String, Any?>>>() {}.type
+    private val queueLock = Any()
+    @Volatile
+    private var queueRestored: Boolean = false
     private val eventQueue = ConcurrentLinkedQueue<Map<String, Any?>>()
 
     private val flushTask = AppExecutorUtil.getAppScheduledExecutorService()
-        .scheduleWithFixedDelay(::flush, 5, 5, TimeUnit.MINUTES)
+        .scheduleWithFixedDelay(::flush, 1, 1, TimeUnit.MINUTES)
 
     private fun getDistinctId(): String {
         val licensedTo = LicensingFacade.getInstance()?.getLicensedToMessage()
@@ -35,6 +44,7 @@ open class AnalyticsService(
 
     fun capture(event: String, properties: Map<String, Any?> = emptyMap()) {
         if (!settings.isEnabled) return
+        ensureQueueRestored()
 
         val allProperties = buildMap {
             putAll(collectEnvironmentProperties())
@@ -51,7 +61,10 @@ open class AnalyticsService(
             }
         )
 
-        eventQueue.add(eventData)
+        synchronized(queueLock) {
+            eventQueue.add(eventData)
+            persistQueueToDisk()
+        }
 
         if (eventQueue.size >= MAX_QUEUE_SIZE) {
             flush()
@@ -98,13 +111,22 @@ open class AnalyticsService(
         }
     }
 
-    private fun flush() {
-        if (eventQueue.isEmpty()) return
+    fun flushPendingEvents() {
+        ensureQueueRestored()
+        flush()
+    }
 
-        val batch = mutableListOf<Map<String, Any?>>()
-        while (batch.size < MAX_QUEUE_SIZE) {
-            val event = eventQueue.poll() ?: break
-            batch.add(event)
+    private fun flush() {
+        ensureQueueRestored()
+        val batch = synchronized(queueLock) {
+            if (eventQueue.isEmpty()) return
+
+            val extracted = mutableListOf<Map<String, Any?>>()
+            while (extracted.size < MAX_QUEUE_SIZE) {
+                val event = eventQueue.poll() ?: break
+                extracted.add(event)
+            }
+            extracted
         }
 
         if (batch.isEmpty()) return
@@ -114,7 +136,54 @@ open class AnalyticsService(
             "batch" to batch
         )
 
-        try {
+        val delivered = sendBatch(payload)
+        synchronized(queueLock) {
+            if (!delivered) {
+                batch.forEach(eventQueue::add)
+            }
+            persistQueueToDisk()
+        }
+    }
+
+    override fun dispose() {
+        flushTask.cancel(false)
+        ensureQueueRestored()
+        if (shouldFlushOnDispose()) {
+            flush()
+        } else {
+            synchronized(queueLock) {
+                persistQueueToDisk()
+            }
+        }
+    }
+
+    protected open fun shouldFlushOnDispose(): Boolean {
+        return try {
+            val app = ApplicationManager.getApplication()
+            !app.isDisposed && !app.isDisposeInProgress
+        } catch (_: IllegalStateException) {
+            false
+        }
+    }
+
+    fun flushBeforePluginUnload() {
+        ensureQueueRestored()
+        if (shouldFlushBeforePluginUnload()) {
+            flush()
+        }
+    }
+
+    protected open fun shouldFlushBeforePluginUnload(): Boolean {
+        return try {
+            val app = ApplicationManager.getApplication()
+            !app.isDisposed && !app.isDisposeInProgress
+        } catch (_: IllegalStateException) {
+            false
+        }
+    }
+
+    protected open fun sendBatch(payload: Map<String, Any?>): Boolean {
+        return try {
             HttpRequests.post("${config.posthogHost}/batch/", "application/json")
                 .tuner { connection ->
                     connection.setRequestProperty("Content-Type", "application/json")
@@ -125,15 +194,60 @@ open class AnalyticsService(
                     if (response.responseCode != 200) {
                         LOG.warn("PostHog batch failed: ${response.responseCode}")
                     }
+                    response.responseCode == 200
                 }
         } catch (e: Exception) {
             LOG.warn("Failed to send analytics batch", e)
+            false
         }
     }
 
-    override fun dispose() {
-        flushTask.cancel(false)
-        flush()
+    protected open fun getQueueStorageFilePath(): Path? {
+        val safePluginId = config.pluginId.replace('.', '_')
+        return Path.of(PathManager.getSystemPath(), "${safePluginId}_analytics_queue.json")
+    }
+
+    private fun ensureQueueRestored() {
+        if (queueRestored) return
+        synchronized(queueLock) {
+            if (queueRestored) return
+            restoreQueueFromDisk()
+            queueRestored = true
+        }
+    }
+
+    private fun restoreQueueFromDisk() {
+        val storageFile = getQueueStorageFilePath() ?: return
+        if (!Files.exists(storageFile)) return
+
+        try {
+            val raw = Files.readString(storageFile)
+            val restored: List<Map<String, Any?>> = gson.fromJson(raw, queueType) ?: emptyList()
+            if (restored.isNotEmpty()) {
+                restored.forEach(eventQueue::add)
+            }
+        } catch (e: Exception) {
+            LOG.warn("Failed to restore analytics queue", e)
+        }
+    }
+
+    private fun persistQueueToDisk() {
+        val storageFile = getQueueStorageFilePath() ?: return
+        try {
+            if (eventQueue.isEmpty()) {
+                Files.deleteIfExists(storageFile)
+                return
+            }
+
+            val parent = storageFile.parent
+            if (parent != null) {
+                Files.createDirectories(parent)
+            }
+            val snapshot = eventQueue.toList()
+            Files.writeString(storageFile, gson.toJson(snapshot))
+        } catch (e: Exception) {
+            LOG.warn("Failed to persist analytics queue", e)
+        }
     }
 
     private fun collectEnvironmentProperties(): Map<String, String> {

--- a/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsSettings.kt
+++ b/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsSettings.kt
@@ -1,6 +1,5 @@
 package dev.meanmail.analytics
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.PersistentStateComponent
 
 class AnalyticsSettingsState {
@@ -20,7 +19,6 @@ abstract class AnalyticsSettings : PersistentStateComponent<AnalyticsSettingsSta
         get() = state.consentState
         set(value) {
             state.consentState = value
-            ApplicationManager.getApplication().saveSettings()
         }
 
     val isEnabled: Boolean

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ jvmVersion=21
 group=dev.meanmail
 repository=https://github.com/meanmail-dev/nginx-intellij-plugin
 pluginName=Nginx Configuration
-version=2026.1.13
+version=2026.1.14
 # https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 kotlin.stdlib.default.dependency=false
 #

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,6 +105,14 @@
 Your ratings and feedback are very important. The feature will appear the faster the more people request it.
 ]]></description>
     <change-notes><![CDATA[
+<b>2026.1.14 (April, 15, 2026)</b>
+<ul>
+    <li>Fix crash when analytics consent state is saved during dispose under write lock</li>
+    <li>Persist analytics event queue to disk to prevent data loss on shutdown</li>
+    <li>Avoid network calls during application shutdown in analytics service</li>
+    <li>Retry failed analytics batch sends on next flush</li>
+</ul>
+
 <b>2026.1.13 (April, 1, 2026)</b>
 <ul>
     <li>Fix analytics consent dialog reappearing after user denial</li>

--- a/src/test/kotlin/dev/meanmail/analytics/AnalyticsServiceDisposeTest.kt
+++ b/src/test/kotlin/dev/meanmail/analytics/AnalyticsServiceDisposeTest.kt
@@ -1,0 +1,152 @@
+package dev.meanmail.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class AnalyticsServiceDisposeTest {
+    @Test
+    fun `dispose flushes queued events when allowed`() {
+        val service = RecordingAnalyticsService(
+            sendBatchResult = true,
+            shouldFlushOnDispose = true,
+        )
+        enqueueEvent(service)
+
+        service.dispose()
+
+        assertEquals(1, service.sendBatchCalls)
+        assertEquals(0, getQueueSize(service))
+    }
+
+    @Test
+    fun `dispose skips flush when shutdown is in progress`() {
+        val service = RecordingAnalyticsService(
+            sendBatchResult = true,
+            shouldFlushOnDispose = false,
+        )
+        enqueueEvent(service)
+
+        service.dispose()
+
+        assertEquals(0, service.sendBatchCalls)
+        assertTrue(getQueueSize(service) > 0)
+    }
+
+    @Test
+    fun `failed flush keeps events in queue`() {
+        val service = RecordingAnalyticsService(
+            sendBatchResult = false,
+            shouldFlushOnDispose = true,
+        )
+        enqueueEvent(service)
+
+        service.dispose()
+
+        assertEquals(1, service.sendBatchCalls)
+        assertTrue(getQueueSize(service) > 0)
+    }
+
+    @Test
+    fun `events are restored from disk on next service instance`() {
+        val storageFile = Files.createTempFile("analytics-queue-", ".json")
+        Files.deleteIfExists(storageFile)
+
+        val first = RecordingAnalyticsService(
+            sendBatchResult = true,
+            shouldFlushOnDispose = false,
+            storageFile = storageFile,
+        )
+        enqueueEvent(first)
+        first.dispose()
+
+        assertTrue(Files.exists(storageFile))
+
+        val second = RecordingAnalyticsService(
+            sendBatchResult = true,
+            shouldFlushOnDispose = false,
+            storageFile = storageFile,
+        )
+
+        second.flushPendingEvents()
+        assertEquals(1, second.sendBatchCalls)
+        assertFalse(Files.exists(storageFile))
+        assertEquals(0, getQueueSize(second))
+    }
+
+    @Test
+    fun `plugin unload flushes when allowed`() {
+        val service = RecordingAnalyticsService(
+            sendBatchResult = true,
+            shouldFlushOnDispose = false,
+            shouldFlushBeforePluginUnload = true,
+        )
+        enqueueEvent(service)
+
+        service.flushBeforePluginUnload()
+
+        assertEquals(1, service.sendBatchCalls)
+        assertEquals(0, getQueueSize(service))
+    }
+
+    private fun enqueueEvent(service: AnalyticsService) {
+        getQueue(service).add(
+            mapOf(
+                "event" to "test_event",
+                "distinct_id" to "test-id",
+                "properties" to emptyMap<String, Any>(),
+                "timestamp" to "2026-04-12T00:00:00Z",
+            )
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun getQueue(service: AnalyticsService): ConcurrentLinkedQueue<Map<String, Any?>> {
+        val field = AnalyticsService::class.java.getDeclaredField("eventQueue")
+        field.isAccessible = true
+        return field.get(service) as ConcurrentLinkedQueue<Map<String, Any?>>
+    }
+
+    private fun getQueueSize(service: AnalyticsService): Int = getQueue(service).size
+
+    private class RecordingAnalyticsService(
+        private val sendBatchResult: Boolean,
+        private val shouldFlushOnDispose: Boolean,
+        private val shouldFlushBeforePluginUnload: Boolean = true,
+        private val storageFile: Path? = null,
+    ) : AnalyticsService(TestConfig(), TestSettings()) {
+        var sendBatchCalls: Int = 0
+
+        override fun sendBatch(payload: Map<String, Any?>): Boolean {
+            sendBatchCalls++
+            return sendBatchResult
+        }
+
+        override fun shouldFlushOnDispose(): Boolean = shouldFlushOnDispose
+
+        override fun shouldFlushBeforePluginUnload(): Boolean = shouldFlushBeforePluginUnload
+
+        override fun getQueueStorageFilePath(): Path? = storageFile
+    }
+
+    private class TestConfig : AnalyticsConfig {
+        override val posthogApiKey: String = "test-api-key"
+        override val pluginId: String = "dev.meanmail.plugin.nginx-intellij-plugin"
+        override val notificationGroupId: String = "Nginx Analytics"
+        override val pluginDisplayName: String = "Nginx Configuration"
+    }
+
+    private class TestSettings : AnalyticsSettings() {
+        init {
+            loadState(
+                AnalyticsSettingsState().apply {
+                    consentState = ConsentState.ACCEPTED
+                }
+            )
+        }
+    }
+}

--- a/src/test/kotlin/dev/meanmail/analytics/AnalyticsSettingsTest.kt
+++ b/src/test/kotlin/dev/meanmail/analytics/AnalyticsSettingsTest.kt
@@ -1,0 +1,16 @@
+package dev.meanmail.analytics
+
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class AnalyticsSettingsTest : BasePlatformTestCase() {
+    fun testConsentStateUpdateInsideWriteActionDoesNotFail() {
+        val settings = NginxAnalyticsSettings()
+
+        runWriteAction {
+            settings.consentState = ConsentState.ACCEPTED
+        }
+
+        assertEquals(ConsentState.ACCEPTED, settings.consentState)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix crash when analytics consent state is saved during dispose under write lock (removes explicit `saveSettings()` call)
- Persist analytics event queue to disk to prevent data loss on shutdown
- Avoid network calls during application shutdown in analytics service
- Retry failed analytics batch sends on next flush
- Flush interval reduced from 5 minutes to 1 minute

Ported from nginx-pro.

## Test plan
- [x] `AnalyticsSettingsTest` — verifies consent state update inside write action does not fail
- [x] `AnalyticsServiceDisposeTest` — verifies dispose/flush/restore/retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)