### PR TITLE
Replace internal PluginManagerCore.getPlugin with public PluginManager API

### DIFF
--- a/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsService.kt
+++ b/analytics/src/main/kotlin/dev/meanmail/analytics/AnalyticsService.kt
@@ -2,7 +2,7 @@ package dev.meanmail.analytics
 
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationInfo
@@ -242,7 +242,7 @@ open class AnalyticsService(
     private fun collectEnvironmentProperties(): Map<String, String> {
         val appInfo = ApplicationInfo.getInstance()
         val pluginId = PluginId.getId(config.pluginId)
-        val plugin = PluginManagerCore.getPlugin(pluginId)
+        val plugin = PluginManager.getInstance().findEnabledPlugin(pluginId)
 
         return buildMap {
             put("plugin_id", pluginId.idString)

--- a/src/main/kotlin/dev/meanmail/codeInsight/profeatures/ProFeaturePromptService.kt
+++ b/src/main/kotlin/dev/meanmail/codeInsight/profeatures/ProFeaturePromptService.kt
@@ -1,5 +1,6 @@
 package dev.meanmail.codeInsight.profeatures
 
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
@@ -69,6 +70,6 @@ class ProFeaturePromptService : PersistentStateComponent<ProFeaturePromptState> 
 
     private fun isProInstalled(): Boolean {
         val pluginId = PluginId.getId("dev.meanmail.plugin.nginx-intellij-plugin-pro")
-        return com.intellij.ide.plugins.PluginManagerCore.getPlugin(pluginId) != null
+        return PluginManager.getInstance().findEnabledPlugin(pluginId) != null
     }
 }


### PR DESCRIPTION
## Summary

`PluginManagerCore.getPlugin(PluginId)` is an internal IntelliJ Platform API and must not be used outside the platform itself. The plugin verifier flags it as internal API usage.

Replaced both usages with the public `PluginManager.getInstance().findEnabledPlugin(pluginId)`:

- `analytics/.../AnalyticsService.kt` — resolving the plugin descriptor to read its version in `collectEnvironmentProperties()`.
- `src/.../profeatures/ProFeaturePromptService.kt` — `isProInstalled()` presence check.

## Notes

`getPlugin()` returned a descriptor even for a *disabled* plugin, whereas `findEnabledPlugin()` only returns *enabled* ones. This is fine (and arguably more correct) for both call sites: the analytics plugin is always enabled while its own code runs, and the Pro check is meaningfully about an *enabled* Pro plugin.

## Verification

`./gradlew :analytics:compileKotlin compileKotlin` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)