### PR TITLE
Guard README claims against drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Nginx Configuration for JetBrains IDEs
 
+<!--
+Maintenance: verify feature claims against plugin.xml and shipped behavior. Do not add manually
+maintained download, rating, star, or repository counts.
+-->
+
 [![JetBrains Marketplace rating](https://img.shields.io/jetbrains/plugin/r/stars/15461?label=Marketplace%20rating)](https://plugins.jetbrains.com/plugin/15461-nginx-configuration)
 [![JetBrains Marketplace downloads](https://img.shields.io/jetbrains/plugin/d/15461)](https://plugins.jetbrains.com/plugin/15461-nginx-configuration)
 


### PR DESCRIPTION
## What changed

Added a non-rendered maintenance note requiring README feature claims to be checked against plugin metadata and shipped behavior, while prohibiting manually maintained download, rating, star, and repository counts.

## Why

The previous README and organization profile drifted because volatile figures and product claims were duplicated manually. This guardrail keeps future README maintenance tied to authoritative sources.

## Validation

- GitHub Markdown rendering still contains the expected public heading
- git diff check passed
- rendered public copy is unchanged